### PR TITLE
Gunw merged ts

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ GIAnT time series processing of ISCEv2 interferograms
    ```
    sds pkg import container-hysds_giant_time_series.<version>.sdspkg.tar
    ```
-1. Add datasets config for `filtered-ifg-stack` and `displacement-time-series` to your *datasets.json* templates 
+1. Add datasets config for `filtered-ifg-stack`, `filtered-gunw-merged-stack`, and `displacement-time-series` to your *datasets.json* templates 
 under *~/.sds/files* on `mozart`. Example config entries can be found [here](conf/datasets.json).
 1. On `mozart`, recreate the code/config bundles and ship:
    ```
@@ -22,7 +22,7 @@ under *~/.sds/files* on `mozart`. Example config entries can be found [here](con
 
 ## Filtered Interferogram Stack
 ### Description
-The filtered interferogram (`IFG`) stack dataset (`filtered-ifg-stack`) is primarily the HDF5 `RAW-STACK.h5` and 
+The filtered interferogram (`IFG`) stack datasets (`filtered-ifg-stack`) and (`filtered-gunw-merged-stack`) are primarily the HDF5 `RAW-STACK.h5` and 
 `PROC-STACK.h5` outputs of GIAnT's `PrepIgramStack.py` and `ProcessStack.py`, respectively. Prior to
 running these PGEs, a first-order filtering step is performed to filter out IFGs whose track and subswaths
 don't match those specified. Additionally, IFGs are filtered whose reference bounding box contains no data

--- a/conf/datasets.json
+++ b/conf/datasets.json
@@ -22,6 +22,28 @@
         ]
       }
     },
+    {
+      "ipath": "ariamh::data/filtered-gunw-merged-stack",
+      "match_pattern": "/(?P<id>filtered-gunw-merged-stack_.+?-TN\\d+-.+-(?P<year>\\d{4})(?P<month>\\d{2})(?P<day>\\d{2})T\\d{6}Z-\\w{5}-v.+)$",
+      "alt_match_pattern": null,
+      "extractor": null,
+      "level": "l3",
+      "type": "gunw-merged-stack",
+      "publish": {
+        "s3-profile-name": "default",
+        "location": "s3://{{ DATASET_S3_ENDPOINT }}:80/{{ DATASET_BUCKET }}/datasets/{type}/{version}/{id}",
+        "urls": [
+          "http://{{ DATASET_BUCKET }}.{{ DATASET_S3_WEBSITE_ENDPOINT }}/datasets/{type}/{version}/{id}",
+          "s3://{{ DATASET_S3_ENDPOINT }}:80/{{ DATASET_BUCKET }}/datasets/{type}/{version}/{id}"
+        ]
+      },
+      "browse": {
+        "location": "davs://{{ DAV_USER }}:{{ DAV_PASSWORD }}@{{ DAV_SERVER }}/browse/{type}/{version}/{id}",
+        "urls": [
+          "https://{{ DAV_SERVER }}/browse/{type}/{version}/{id}"
+        ]
+      }
+    },
     { 
       "ipath": "ariamh::data/displacement-time-series",
       "match_pattern": "/(?P<id>displacement-time-series-.+_.+?-TN\\d+-.+-(?P<year>\\d{4})(?P<month>\\d{2})(?P<day>\\d{2})T\\d{6}Z-\\w{5}-v.+)$",

--- a/scripts/create_displacement_time_series.py
+++ b/scripts/create_displacement_time_series.py
@@ -29,7 +29,7 @@ logger = logging.getLogger(os.path.splitext(os.path.basename(__file__))[0])
 BASE_PATH = os.path.dirname(__file__)
 
 
-ID_RE = re.compile(r'filtered-ifg-stack_(.+)-v.+$')
+ID_RE = re.compile(r'filtered-gunw-merged-stack_(.+)-v.+$')
 DATASET_VERSION = "v0.1"
 
 

--- a/scripts/create_displacement_time_series.sh
+++ b/scripts/create_displacement_time_series.sh
@@ -8,6 +8,16 @@ echo $BASE_PATH
 PGE_PATH=$(cd "${BASE_PATH}/.."; pwd)
 BIN_PATH=$PGE_PATH/scripts
 
+# move symlinked products
+INPUT_DIR=orig_symlinked_inputs
+if [ ! -d "$INPUT_DIR" ]; then
+   mkdir $INPUT_DIR
+   mv filtered-gunw-merged-stack* $INPUT_DIR/
+   cd $INPUT_DIR
+   cp -aL filtered-gunw-merged-stack* ..
+   cd ..
+fi 
+
 # source ISCE env
 export GMT_HOME=/usr/local/gmt
 source $BIN_PATH/isce.sh

--- a/scripts/create_filtered_gunw_merged_stack.py
+++ b/scripts/create_filtered_gunw_merged_stack.py
@@ -277,6 +277,7 @@ def main(input_json_file):
     gap_file = "gaps.txt"
     with open(gap_file, "w") as f:
         if not connected:
+            full_coverage = False
             f.write("Temporal gaps:\n")
             it1, it2 = 0, 1
             while it2 < len(intervals):
@@ -284,6 +285,7 @@ def main(input_json_file):
                 it1 += 1
                 it2 += 1
         else:
+            full_coverage = True
             f.write("No temporal gaps")
     shutil.move(gap_file, os.path.join(prod_dir, gap_file))
     
@@ -332,6 +334,7 @@ def main(input_json_file):
         "ifgs": [ifg_info[i]['product'] for i in sorted(ifg_info)],
         "timestep_count": len(timesteps),
         "timesteps": timesteps,
+        "full_coverage": full_coverage
     }
     if connected: met['tags'] = 'temporally_connected'
     met_file = os.path.join(prod_dir, "{}.met.json".format(id))

--- a/scripts/create_filtered_gunw_merged_stack.sh
+++ b/scripts/create_filtered_gunw_merged_stack.sh
@@ -39,5 +39,5 @@ if [ $STATUS -ne 0 ]; then
 fi
 
 # copy log to dataset
-cp create_filtered_gunw_merged_stack.log filtered-ifg-stack*/
+cp create_filtered_gunw_merged_stack.log filtered-gunw-merged-stack*/
 

--- a/scripts/create_filtered_gunw_merged_stack.sh
+++ b/scripts/create_filtered_gunw_merged_stack.sh
@@ -1,12 +1,17 @@
 #!/bin/bash
 BASE_PATH=$(dirname "${BASH_SOURCE}")
-echo $BASE_PATH
 BASE_PATH=$(cd "${BASE_PATH}"; pwd)
-echo $BASE_PATH
 
 # set PGE path
 PGE_PATH=$(cd "${BASE_PATH}/.."; pwd)
 BIN_PATH=$PGE_PATH/scripts
+
+# move symlinked products
+mkdir orig_symlinked_inputs
+mv S1-GUNW-MERGED* orig_symlinked_inputs/
+cd orig_symlinked_inputs
+cp -aL S1-GUNW-MERGED* ..
+cd ..
 
 # source ISCE env
 export GMT_HOME=/usr/local/gmt

--- a/scripts/create_filtered_gunw_merged_stack.sh
+++ b/scripts/create_filtered_gunw_merged_stack.sh
@@ -7,11 +7,14 @@ PGE_PATH=$(cd "${BASE_PATH}/.."; pwd)
 BIN_PATH=$PGE_PATH/scripts
 
 # move symlinked products
-mkdir orig_symlinked_inputs
-mv S1-GUNW-MERGED* orig_symlinked_inputs/
-cd orig_symlinked_inputs
-cp -aL S1-GUNW-MERGED* ..
-cd ..
+INPUT_DIR=orig_symlinked_inputs
+if [ ! -d "$INPUT_DIR" ]; then
+   mkdir $INPUT_DIR
+   mv S1-GUNW-MERGED* $INPUT_DIR/
+   cd $INPUT_DIR
+   cp -aL S1-GUNW-MERGED* ..
+   cd ..
+fi
 
 # source ISCE env
 export GMT_HOME=/usr/local/gmt


### PR DESCRIPTION
Changes:
- Added create_displacement_time_series.py and create_displacement_time_series.sh
- Added 'full_coverage' parameter in met.json
- Updated key names in create_filtered_gunw_merged_stack.py to accept new key names from _context.json
- (Hot fix) Changed PGEs to move the input products into the “INPUT_DIR” directory, remove the symlink, and repopulate the inputs into the work directory
